### PR TITLE
Add GitHub integration utilities

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,7 +1,7 @@
 # Development Plan
 
 ## Phase 1: Core Implementation
-- [ ] **Feature:** Multi-Language Support
+- [x] **Feature:** Multi-Language Support
 - [ ] **Feature:** GitHub Integration
 - [ ] **Feature:** Configurable Rules
 - [ ] **Feature:** Learning System

--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ review_criteria:
   documentation: true
 ```
 
+### Linter Configuration
+
+The bot uses language-specific linters to check code style. A YAML file can
+override the default mapping of languages to linting tools:
+
+```yaml
+# linters.yaml
+linters:
+  python: ruff
+  javascript: eslint
+  typescript: eslint
+  go: golangci-lint
+```
+
+Pass the path to this file when invoking `analyze_pr` to customize which
+linters run for each language.
+Unspecified languages fall back to the built-in defaults for Python,
+JavaScript, and TypeScript.
+
+Example usage:
+
+```python
+from autogen_code_review_bot import analyze_pr
+
+result = analyze_pr("/path/to/repo", config_path="linters.yaml")
+print(result.style.output)
+```
+
 ## Usage Examples
 
 ### Manual Review

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -3,7 +3,4 @@
 ## Backlog
 | Task | Owner | Priority | Status |
 | --- | --- | --- | --- |
-| Add language detection utility | @agent | P1 | Todo |
-| Integrate language-specific linters in analyze_pr | @agent | P1 | Todo |
-| Load linter configuration from YAML | @agent | P2 | Todo |
-| Document multi-language setup in README | @agent | P3 | Todo |
+| Implement GitHub Integration | @agent | P1 | Todo |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "autogen_code_review_bot"
 version = "0.0.1"
 requires-python = ">=3.8"
+dependencies = ["PyYAML", "requests"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/autogen_code_review_bot/__init__.py
+++ b/src/autogen_code_review_bot/__init__.py
@@ -6,7 +6,9 @@ from .agents import (
     load_agents_from_yaml,
     run_dual_review,
 )
-from .pr_analysis import PRAnalysisResult, analyze_pr
+from .pr_analysis import PRAnalysisResult, analyze_pr, load_linter_config
+from .language_detection import detect_language
+from .github_integration import get_pull_request_diff, post_comment
 
 __all__ = [
     "AgentConfig",
@@ -17,4 +19,8 @@ __all__ = [
     "run_dual_review",
     "PRAnalysisResult",
     "analyze_pr",
+    "detect_language",
+    "load_linter_config",
+    "get_pull_request_diff",
+    "post_comment",
 ]

--- a/src/autogen_code_review_bot/github_integration.py
+++ b/src/autogen_code_review_bot/github_integration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+import requests
+
+API_URL = "https://api.github.com"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+
+
+def get_pull_request_diff(repo: str, pr_number: int, token: str) -> str:
+    """Return the diff for ``pr_number`` in ``repo``.
+
+    ``repo`` should be in the form ``"owner/name"``.
+    """
+    url = f"{API_URL}/repos/{repo}/pulls/{pr_number}"
+    resp = requests.get(
+        url,
+        headers=_headers(token),
+        params={"media_type": "diff"},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.text
+
+
+def post_comment(repo: str, pr_number: int, body: str, token: str) -> Any:
+    """Post ``body`` as a comment on the pull request."""
+    url = f"{API_URL}/repos/{repo}/issues/{pr_number}/comments"
+    resp = requests.post(
+        url,
+        headers=_headers(token),
+        data=json.dumps({"body": body}),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()

--- a/src/autogen_code_review_bot/language_detection.py
+++ b/src/autogen_code_review_bot/language_detection.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+# Mapping of file extensions to language identifiers
+EXTENSION_MAP = {
+    '.py': 'python',
+    '.js': 'javascript',
+    '.ts': 'typescript',
+    '.go': 'go',
+    '.rs': 'rust',
+}
+
+
+def detect_language(filename: str | Path) -> str:
+    """Return the language associated with ``filename`` based on its extension.
+
+    ``filename`` may be a string or :class:`~pathlib.Path` instance.
+    """
+    ext = Path(filename).suffix.lower()
+    return EXTENSION_MAP.get(ext, 'unknown')

--- a/tests/document_multi_language_setup_in_readme.py
+++ b/tests/document_multi_language_setup_in_readme.py
@@ -1,0 +1,22 @@
+import pytest
+from pathlib import Path
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "Linter Configuration",
+        "linters:",
+        "python: ruff",
+    ],
+)
+def test_instructions_present(phrase):
+    text = README.read_text(encoding="utf-8")
+    assert phrase in text
+
+
+def test_example_snippet():
+    text = README.read_text(encoding="utf-8")
+    assert "```yaml" in text and "linters:" in text

--- a/tests/load_linter_configuration_from_yaml.py
+++ b/tests/load_linter_configuration_from_yaml.py
@@ -1,0 +1,24 @@
+import yaml
+from autogen_code_review_bot.pr_analysis import load_linter_config
+
+
+def test_yaml_parsed(tmp_path):
+    cfg = {"linters": {"python": "mypy", "javascript": "eslint"}}
+    path = tmp_path / "linters.yaml"
+    path.write_text(yaml.dump(cfg))
+    config = load_linter_config(str(path))
+    assert config["python"] == "mypy"
+    assert config["javascript"] == "eslint"
+    assert config["typescript"] == "eslint"  # from defaults
+
+
+def test_fallback_defaults(tmp_path):
+    cfg = {"linters": {"python": "flake8"}}
+    path = tmp_path / "linters.yaml"
+    path.write_text(yaml.dump(cfg))
+    config = load_linter_config(str(path))
+    # specified language overridden
+    assert config["python"] == "flake8"
+    # unspecified languages fall back
+    assert config["javascript"] == "eslint"
+

--- a/tests/sprint_acceptance_criteria.json
+++ b/tests/sprint_acceptance_criteria.json
@@ -1,34 +1,9 @@
 {
-  "add-language-detection-utility": {
-    "description": "Add language detection utility",
+  "github-integration": {
+    "description": "Implement GitHub Integration",
     "cases": {
-      "detects_known_extensions": "Files with .py, .js, .ts, .go, .rs return correct language",
-      "unknown_extension": "Returns 'unknown' for unrecognized extensions"
+      "default_case": "Placeholder for acceptance criteria"
     },
-    "test_file": "tests/add_language_detection_utility.py"
-  },
-  "integrate-language-specific-linters-in-analyze-pr": {
-    "description": "Integrate language-specific linters in analyze_pr",
-    "cases": {
-      "python_linter": "Runs ruff for Python files",
-      "js_linter_missing": "Outputs 'not installed' if eslint is missing"
-    },
-    "test_file": "tests/integrate_language_specific_linters_in_analyze_pr.py"
-  },
-  "load-linter-configuration-from-yaml": {
-    "description": "Load linter configuration from YAML",
-    "cases": {
-      "yaml_parsed": "Reads languages and linters from config file",
-      "fallback_defaults": "Uses default tools when not specified"
-    },
-    "test_file": "tests/load_linter_configuration_from_yaml.py"
-  },
-  "document-multi-language-setup-in-readme": {
-    "description": "Document multi-language setup in README",
-    "cases": {
-      "instructions_present": "README explains how to enable extra languages",
-      "examples_included": "Provides sample config snippet"
-    },
-    "test_file": "tests/document_multi_language_setup_in_readme.py"
+    "test_file": "tests/test_github_integration.py"
   }
 }

--- a/tests/test_add_language_detection_utility.py
+++ b/tests/test_add_language_detection_utility.py
@@ -1,0 +1,25 @@
+import pytest
+from pathlib import Path
+from autogen_code_review_bot.language_detection import detect_language
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("script.py", "python"),
+        ("app.js", "javascript"),
+        ("lib.ts", "typescript"),
+        ("main.go", "go"),
+        ("mod.rs", "rust"),
+    ],
+)
+def test_detects_known_extensions(filename, expected):
+    assert detect_language(filename) == expected
+
+
+def test_accepts_path_object():
+    assert detect_language(Path("foo.py")) == "python"
+
+
+def test_unknown_extension():
+    assert detect_language(Path("readme.txt")) == "unknown"
+

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -1,0 +1,37 @@
+import requests
+from autogen_code_review_bot.github_integration import get_pull_request_diff, post_comment
+
+def test_get_pull_request_diff_calls_api(monkeypatch):
+    called = {}
+
+    def fake_get(url, headers, params, **kwargs):
+        called['url'] = url
+        called['headers'] = headers
+        called['params'] = params
+        class Resp:
+            text = 'diff'
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(requests, 'get', fake_get)
+    diff = get_pull_request_diff('owner/repo', 42, 'token')
+    assert '/repos/owner/repo/pulls/42' in called['url']
+    assert diff == 'diff'
+
+
+def test_post_comment_calls_api(monkeypatch):
+    called = {}
+    def fake_post(url, headers, data, **kwargs):
+        called['url'] = url
+        called['data'] = data
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'ok': True}
+        return Resp()
+    monkeypatch.setattr(requests, 'post', fake_post)
+    resp = post_comment('owner/repo', 42, 'hi', 'token')
+    assert '/repos/owner/repo/issues/42/comments' in called['url']
+    assert resp == {'ok': True}

--- a/tests/test_integrate_language_specific_linters_in_analyze_pr.py
+++ b/tests/test_integrate_language_specific_linters_in_analyze_pr.py
@@ -1,0 +1,15 @@
+from autogen_code_review_bot.pr_analysis import analyze_pr
+
+
+def test_python_linter(tmp_path):
+    (tmp_path / "main.py").write_text("print('hi')\n")
+    result = analyze_pr(str(tmp_path))
+    assert "ruff" in result.style.tool
+
+
+def test_js_linter_missing(tmp_path, monkeypatch):
+    (tmp_path / "app.js").write_text("console.log('hi');\n")
+    monkeypatch.setenv("PATH", "")
+    result = analyze_pr(str(tmp_path))
+    assert "not installed" in result.style.output
+


### PR DESCRIPTION
## Summary
- mark Multi-Language Support as complete and generate new sprint
- add requests dependency
- expose GitHub integration helpers in package API
- implement `get_pull_request_diff` and `post_comment`
- provide unit tests for GitHub integration

## Testing
- `ruff check src tests`
- `bandit -r src -q`
- `radon cc -s -a src`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e88b4a33083299c4b6a36367bbabc

## Summary by Sourcery

Integrate GitHub API utilities for fetching diffs and posting comments, enhance `analyze_pr` to support multi-language linting via a YAML-configurable tool mapping, and add corresponding tests and documentation.

New Features:
- Add GitHub integration helpers `get_pull_request_diff` and `post_comment`

Enhancements:
- Detect repository languages and run configured linters dynamically in `analyze_pr`
- Load language→linter mappings from a YAML config with sensible defaults

Documentation:
- Document linter configuration in README with usage example

Tests:
- Add unit tests for GitHub integration, language detection, linter configuration, and multi-language linting in `analyze_pr`

Chores:
- Expose `detect_language`, `load_linter_config`, `get_pull_request_diff`, and `post_comment` in package API
- Add `requests` and `PyYAML` dependencies
- Mark Multi-Language Support as complete and update sprint board and development plan